### PR TITLE
fix(external config): sort merge to override default configuration

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -22,7 +22,7 @@ module.exports = {
 
     var opts = cli.opts;
 
-    var bumperConfig = merge( { }, cli.getConfig(), opts );
+    var bumperConfig = merge( { }, opts, cli.getConfig()  );
     delete bumperConfig._;
     delete bumperConfig.config;
 


### PR DESCRIPTION
fix issue to override correctly default configuration passed by parameter.

For information only, I use grunt-bump and I have externalized configuration.
With bumpery, I can use the same configuration (company reference) without setting up project.